### PR TITLE
Update ssh2 and ssh2-promise to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
   },
   "dependencies": {
     "aws-sdk": "^2.298.0",
-    "ssh2": "0.8.8",
-    "ssh2-promise": "0.1.6"
+    "ssh2": "0.8.9",
+    "ssh2-promise": "0.1.7"
   },
   "jest": {
     "verbose": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6839,29 +6839,29 @@ sprintf-kit@^2.0.0:
   dependencies:
     es5-ext "^0.10.46"
 
-ssh2-promise@0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/ssh2-promise/-/ssh2-promise-0.1.6.tgz#5758456591dedcfa621007ce588caf49b9ea02e9"
-  integrity sha512-t1tBCGeqelyhVqHFnaxoKbfh3D6Utvy1iMO4+ijwssbM3KDSreDC0RsFaUVIhefBpbrfWsemTu+fAB5kx2w3bQ==
+ssh2-promise@0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/ssh2-promise/-/ssh2-promise-0.1.7.tgz#b5a73870a683aae1d596a75d12c48486714f97a0"
+  integrity sha512-7iaFJQmTKekBzM/nbWZGaC472mqmgqSkz5qAlU8Hj4QIpTHgml/HCMKUX0mc7tOrqNlgwrginURoe+OG+PxnEg==
   dependencies:
     "@heroku/socksv5" "^0.0.9"
-    ssh2 "^0.8.6"
+    ssh2 "^0.8.9"
 
-ssh2-streams@~0.4.9:
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/ssh2-streams/-/ssh2-streams-0.4.9.tgz#d3d92155410001437d27119d9c023b303cbe2309"
-  integrity sha512-glMQKeYKuA+rLaH16fJC3nZMV1BWklbxuYCR4C5/LlBSf2yaoNRpPU7Ul702xsi5nvYjIx9XDkKBJwrBjkDynw==
+ssh2-streams@~0.4.10:
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/ssh2-streams/-/ssh2-streams-0.4.10.tgz#48ef7e8a0e39d8f2921c30521d56dacb31d23a34"
+  integrity sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==
   dependencies:
     asn1 "~0.2.0"
     bcrypt-pbkdf "^1.0.2"
     streamsearch "~0.1.2"
 
-ssh2@0.8.8, ssh2@^0.8.6:
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/ssh2/-/ssh2-0.8.8.tgz#1d9815e287faef623ae2b7db32e674dadbef4664"
-  integrity sha512-egJVQkf3sbjECTY6rCeg8rgV/fab6S/7E5kpYqHT3Fe/YpfJbLYeA1qTcB2d+LRUUAjqKi7rlbfWkaP66YdpAQ==
+ssh2@0.8.9, ssh2@^0.8.9:
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/ssh2/-/ssh2-0.8.9.tgz#54da3a6c4ba3daf0d8477a538a481326091815f3"
+  integrity sha512-GmoNPxWDMkVpMFa9LVVzQZHF6EW3WKmBwL+4/GeILf2hFmix5Isxm7Amamo8o7bHiU0tC+wXsGcUXOxp8ChPaw==
   dependencies:
-    ssh2-streams "~0.4.9"
+    ssh2-streams "~0.4.10"
 
 sshpk@^1.7.0:
   version "1.16.1"


### PR DESCRIPTION
This PR updates `ssh2` from 0.8.8 to 0.8.9 and `ssh2-promise` from 0.1.6 to 0.1.7.

I've tested the resulting Lambda function and it works for me!