### PR TITLE
withdraw support for node 8.x and add GA workflow test for node 16.x

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x, 16.x]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Why

Dependabot security fixes were not working with node 8.x.
